### PR TITLE
matmul, ones and zeros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ Thumbs.db
 
 # Virtual environment
 /lumine_env/
+testtt.py

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(lumine/csrc/cpu)
 include_directories(lumine/csrc/utils)
 
 # Add position-independent code flag
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -mavx2 -mfma -fopenmp -O3 -march=native -ffast-math")
 
 # Create shared library
 add_library(tensor SHARED ${TENSOR_SRC} ${STREAM_SRC} ${MATH_SRC})

--- a/lumine/__init__.py
+++ b/lumine/__init__.py
@@ -66,6 +66,8 @@ class _TensorLib:
             ctypes.c_char_p,
         ]
         cls._lib.zeros.restype = ctypes.c_void_p
+        cls._lib.tensor_matmul.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        cls._lib.tensor_matmul.restype = ctypes.c_void_p
 
     @classmethod
     def get_library(cls):
@@ -144,3 +146,6 @@ def zeros_like(tensor):
         dtype=tensor.dtype.decode("utf-8"),
         device=tensor.device.decode("utf-8"),
     )
+
+def matmul(_this, _other):
+    return _this @ _other

--- a/lumine/__init__.py
+++ b/lumine/__init__.py
@@ -1,1 +1,146 @@
+import ctypes
+import os
+
+VALID_DTYPES = {"float32", "int32"}
+VALID_DEVICES = {"cpu", "gpu"}
+
+
+class _TensorLib:
+    _build_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "build"))
+    _lib_path = os.path.join(_build_dir, "lumine.so")
+    if not os.path.exists(_lib_path):
+        raise RuntimeError(f"Library not found at: {_lib_path}")
+    _lib = ctypes.CDLL(_lib_path)
+
+    @classmethod
+    def _signature(cls):
+        cls._lib.create_tensor.argtypes = [
+            ctypes.c_void_p,  # data ptr
+            ctypes.POINTER(ctypes.c_int),  # shape
+            ctypes.c_int,  # dim
+            ctypes.c_char_p,  # Device
+            ctypes.c_char_p,  # Dtype
+        ]
+
+        cls._lib.create_tensor.restype = ctypes.c_void_p
+        cls._lib.print_tensor.argtypes = [ctypes.c_void_p]
+        cls._lib.print_tensor.restype = ctypes.c_char_p
+        cls._lib.get_item.argtypes = [
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_int),
+            ctypes.c_int,
+        ]
+        cls._lib.get_item.restype = ctypes.c_void_p
+        cls._lib.get_shape.argtypes = [ctypes.c_void_p]
+        cls._lib.get_shape.restype = ctypes.POINTER(ctypes.c_int)
+        cls._lib.astype.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+        cls._lib.astype.restype = ctypes.c_void_p
+        cls._lib.get_data_ptr.argtypes = [ctypes.c_void_p]
+        cls._lib.get_data_ptr.restype = ctypes.c_void_p
+        cls._lib.tensor_add.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        cls._lib.tensor_add.restype = ctypes.c_void_p
+        cls._lib.tensor_sub.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        cls._lib.tensor_sub.restype = ctypes.c_void_p
+        cls._lib.tensor_mul.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        cls._lib.tensor_mul.restype = ctypes.c_void_p
+
+        cls._lib.reshape.argtypes = [
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_int),
+            ctypes.c_int,
+        ]
+        cls._lib.reshape.restype = ctypes.c_void_p
+        cls._lib.get_last_error.argtypes = []
+        cls._lib.get_last_error.restype = ctypes.c_char_p
+        cls._lib.ones.argtypes = [
+            ctypes.POINTER(ctypes.c_int),
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_char_p,
+        ]
+        cls._lib.ones.restype = ctypes.c_void_p
+        cls._lib.zeros.argtypes = [
+            ctypes.POINTER(ctypes.c_int),
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_char_p,
+        ]
+        cls._lib.zeros.restype = ctypes.c_void_p
+
+    @classmethod
+    def get_library(cls):
+        return cls._lib
+
+
+_TensorLib._signature()
+_lib = _TensorLib.get_library()
+
 from .tensor import tensor
+
+
+def check_error(tensor):
+    if not tensor:
+        error_msg = _lib.get_last_error()
+        if error_msg:
+            raise RuntimeError(error_msg.decode("utf-8"))
+        else:
+            raise RuntimeError("Unknown error! Please report this issue.")
+
+def ones(shape, dtype="float32", device="cpu"):
+    if len(shape) == 1 and isinstance(shape[0], (list, tuple)):
+        shape = tuple(shape[0])
+    else:
+        shape = tuple(shape)
+
+    if len(shape) == 0:
+        raise ValueError("Shape cannot be empty.")
+
+    if dtype not in VALID_DTYPES:
+        raise ValueError(f"Invalid dtype: {dtype}. Supported: {VALID_DTYPES}")
+    if device not in VALID_DEVICES:
+        raise ValueError(f"Invalid device: {device}. Supported: {VALID_DEVICES}")
+
+    device = device.encode("utf-8") if isinstance(device, str) else device
+    dtype = dtype.encode("utf-8") if isinstance(dtype, str) else dtype
+
+    shape_array = (ctypes.c_int * len(shape))(*shape)
+    tensor_ptr = _lib.ones(shape_array, len(shape), device, dtype)
+    return tensor(_tensor=tensor_ptr, dtype=dtype, device=device, ndim=len(shape))
+
+
+def zeros(shape, dtype="float32", device="cpu"):
+    if len(shape) == 1 and isinstance(shape[0], (list, tuple)):
+        shape = tuple(shape[0])
+    else:
+        shape = tuple(shape)
+
+    if len(shape) == 0:
+        raise ValueError("Shape cannot be empty.")
+
+    if dtype not in VALID_DTYPES:
+        raise ValueError(f"Invalid dtype: {dtype}. Supported: {VALID_DTYPES}")
+    if device not in VALID_DEVICES:
+        raise ValueError(f"Invalid device: {device}. Supported: {VALID_DEVICES}")
+
+    device = device.encode("utf-8") if isinstance(device, str) else device
+    dtype = dtype.encode("utf-8") if isinstance(dtype, str) else dtype
+
+    shape_array = (ctypes.c_int * len(shape))(*shape)
+    tensor_ptr = _lib.zeros(shape_array, len(shape), device, dtype)
+    return tensor(_tensor=tensor_ptr, dtype=dtype, device=device, ndim=len(shape))
+
+
+def ones_like(tensor):
+    return ones(
+        tensor.shape,
+        dtype=tensor.dtype.decode("utf-8"),
+        device=tensor.device.decode("utf-8"),
+    )
+
+
+def zeros_like(tensor):
+    return zeros(
+        tensor.shape,
+        dtype=tensor.dtype.decode("utf-8"),
+        device=tensor.device.decode("utf-8"),
+    )

--- a/lumine/csrc/cpu/math.h
+++ b/lumine/csrc/cpu/math.h
@@ -8,14 +8,12 @@ void cpu_tensor_add(Tensor<T>& out, Tensor<T>& t2);
 template <typename T>
 void cpu_tensor_sub(Tensor<T>& out, Tensor<T>& t2);
 template <typename T>
+void cpu_tensor_mul(Tensor<T>& out, Tensor<T>& t2);
+template <typename T>
 void cpu_tensor_add_broadcast(Tensor<T>& out, const Tensor<T>& t1, const Tensor<T>& t2, int *broadcast_shape, int broadcast_ndim);
-
 template <typename T>
 void cpu_tensor_sub_broadcast(Tensor<T>& out, const Tensor<T>& t1, const Tensor<T>& t2, int *broadcast_shape, int broadcast_ndim);
-
 template <typename T>
 void cpu_tensor_mul_broadcast(Tensor<T>& out, const Tensor<T>& t1, const Tensor<T>& t2, int *broadcast_shape, int broadcast_ndim);
 
-template <typename T>
-void cpu_tensor_mul(Tensor<T>& out, Tensor<T>& t2);
 #endif // CPU_H

--- a/lumine/csrc/tensor.cpp
+++ b/lumine/csrc/tensor.cpp
@@ -6,8 +6,54 @@
 #include "tensor.h"
 #include "utils/stream.h"
 #include "cpu/math.h"
+#include <cstdlib>
+
+#if defined(_WIN32)  // Windows
+#include <windows.h>
+
+int get_cache_size() {
+    DWORD buffer_size = 0;
+    GetLogicalProcessorInformationEx(RelationCache, NULL, &buffer_size);
+    SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX* buffer = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)malloc(buffer_size);
+    GetLogicalProcessorInformationEx(RelationCache, buffer, &buffer_size);
+
+    int cache_size = buffer->Cache.CacheSize;
+    free(buffer);
+    return cache_size;
+}
+
+#elif defined(__linux__)
+#include <fstream>
+
+int get_cache_size() {
+    std::ifstream file("/sys/devices/system/cpu/cpu0/cache/index0/size");
+    if (!file) {
+        return 32 * 1024;
+    }
+    int cache_size;
+    file >> cache_size;
+    return cache_size * 1024;
+}
+
+#elif defined(__APPLE__)
+#include <sys/sysctl.h>
+
+int get_cache_size() {
+    size_t cache_size;
+    size_t size = sizeof(cache_size);
+    sysctlbyname("hw.l1dcachesize", &cache_size, &size, NULL, 0);
+    return cache_size;
+}
+
+#else  // Fallback
+int get_cache_size() {
+    return 32 * 1024;
+}
+#endif
 
 thread_local std::string last_error;
+const int BLOCK_SIZE = get_cache_size();
+
 inline std::string DTypeToString(DType dt) {
     switch (dt) {
     case DType::FLOAT32:
@@ -277,6 +323,94 @@ Tensor<T>* tensor_mul_impl(Tensor<T>* t1, Tensor<T>* t2) {
     delete[] broadcast_shape;
     throw std::runtime_error("Shape mismatch for tensor multiplication!");
 }
+
+template <typename T>
+Tensor<T>* tensor_matmul_impl(Tensor<T>& A, Tensor<T>& B) {
+    // cache efficient implementation ig?
+    // room for optimization still there
+    // TODO: check for possible optimization or better implementation
+    // whatever that makes this faster, the better
+    const int* shapeA = A.get_shape();
+    const int* shapeB = B.get_shape();
+    int dimsA = A.get_ndim();
+    int dimsB = B.get_ndim();
+
+    if (dimsA < 2 || dimsB < 2) {
+        throw std::runtime_error("Both tensors must have at least 2 dimensions for matrix multiplication.");
+    }
+
+    int batch_dims = std::max(dimsA, dimsB) - 2;
+    int batch_shape[batch_dims];
+
+    for (int i = 0; i < batch_dims; i++) {
+        int dimA = (i < dimsA - 2) ? shapeA[i] : 1;
+        int dimB = (i < dimsB - 2) ? shapeB[i] : 1;
+
+        if (dimA != dimB && dimA != 1 && dimB != 1) {
+            throw std::runtime_error("Batch dimensions are not broadcastable.");
+        }
+        batch_shape[i] = std::max(dimA, dimB);
+    }
+
+    int N = shapeA[dimsA - 2];
+    int K = shapeA[dimsA - 1];
+    int M = shapeB[dimsB - 1];
+
+    if (K != shapeB[dimsB - 2]) {
+        throw std::runtime_error("Matrix multiplication shape mismatch.");
+    }
+
+    int batch_size = 1;
+    for (int i = 0; i < batch_dims; i++) {
+        batch_size *= batch_shape[i];
+    }
+
+    T* result = new T[batch_size * N * M]();
+
+    T* A_data = static_cast<T*>(A.get_data_ptr());
+    T* B_data = static_cast<T*>(B.get_data_ptr());
+
+    #pragma omp parallel for collapse(3)
+    for (int b = 0; b < batch_size; ++b) {
+        int batch_A = 0, batch_B = 0;
+        int temp_b = b;
+        for (int i = batch_dims - 1; i >= 0; i--) {
+            int idx = temp_b % batch_shape[i];
+            temp_b /= batch_shape[i];
+
+            batch_A = (shapeA[i] == batch_shape[i]) ? batch_A * shapeA[i] + idx : batch_A;
+            batch_B = (shapeB[i] == batch_shape[i]) ? batch_B * shapeB[i] + idx : batch_B;
+        }
+
+        for (int i = 0; i < N; i += BLOCK_SIZE) {
+            for (int j = 0; j < M; j += BLOCK_SIZE) {
+                for (int k = 0; k < K; k += BLOCK_SIZE) {
+                    for (int ii = i; ii < std::min(i + BLOCK_SIZE, N); ++ii) {
+                        for (int kk = k; kk < std::min(k + BLOCK_SIZE, K); ++kk) {
+                            T temp = A_data[batch_A * (N * K) + ii * K + kk];
+
+                            for (int jj = j; jj < std::min(j + BLOCK_SIZE, M); ++jj) {
+                                result[b * (N * M) + ii * M + jj] += temp * B_data[batch_B * (K * M) + kk * M + jj];
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    int result_shape[batch_dims + 2];
+    for (int i = 0; i < batch_dims; i++) {
+        result_shape[i] = batch_shape[i];
+    }
+    result_shape[batch_dims] = N;
+    result_shape[batch_dims + 1] = M;
+
+    return new Tensor<T>(result, result_shape, batch_dims + 2, "cpu",
+                         std::is_same<T, float>::value ? DType::FLOAT32 : DType::INT32);
+}
+
+
 // Explicit instantiation for supported types
 template class Tensor<float>;
 template class Tensor<int>;
@@ -284,6 +418,8 @@ template class Tensor<int>;
 // External C functions
 extern "C" {
     BaseTensor* create_tensor(void* data_ptr, int* shape, int ndim, const char* device, const char* dtype) {
+        // TODO
+        // return signals for error are required to distingush between error types (for eg: runtime, value etc)
         try {
             if (std::strcmp(dtype, "float32") == 0)
                 return new Tensor<float>(static_cast<float*>(data_ptr), shape, ndim, device, DType::FLOAT32);
@@ -534,6 +670,27 @@ extern "C" {
                 int *data = new int[_linear_size];
                 std::fill(data, data + _linear_size, 0);
                 return new Tensor<int>(data, shape, ndim, device, DType::INT32);
+            } else {
+                throw std::runtime_error("Unsupported dtype!");
+            }
+        } catch(const std::exception& e) {
+            last_error = e.what();
+            return nullptr;
+        }
+    }
+
+    BaseTensor *tensor_matmul(const BaseTensor *t1, const BaseTensor *t2) {
+        try {
+            DType dtype1 = t1->get_dtype_enum();
+            DType dtype2 = t2->get_dtype_enum();
+            if (dtype1 == DType::FLOAT32 || dtype2 == DType::FLOAT32) {
+                Tensor<float> *tensor1 = dynamic_cast<Tensor<float> *>(const_cast<BaseTensor *>(t1));
+                Tensor<float> *tensor2 = dynamic_cast<Tensor<float> *>(const_cast<BaseTensor *>(t2));
+                return tensor_matmul_impl(*tensor1, *tensor2);
+            } else if (dtype1 == DType::INT32 || dtype2 == DType::INT32) {
+                Tensor<int> *tensor1 = dynamic_cast<Tensor<int> *>(const_cast<BaseTensor *>(t1));
+                Tensor<int> *tensor2 = dynamic_cast<Tensor<int> *>(const_cast<BaseTensor *>(t2));
+                return tensor_matmul_impl(*tensor1, *tensor2);
             } else {
                 throw std::runtime_error("Unsupported dtype!");
             }

--- a/lumine/csrc/tensor.cpp
+++ b/lumine/csrc/tensor.cpp
@@ -497,4 +497,49 @@ extern "C" {
         return last_error.empty() ? nullptr : last_error.c_str();
     }
 
+    BaseTensor *ones(int *shape, int ndim, const char *device, const char *dtype) {
+        try {
+            int _linear_size = 1;
+            for (int i = 0; i < ndim; i++) {
+                _linear_size *= shape[i];
+            }
+            if (std::strcmp(dtype, "float32") == 0) {
+                float *data = new float[_linear_size];
+                std::fill(data, data + _linear_size, 1.0f);
+                return new Tensor<float>(data, shape, ndim, device, DType::FLOAT32);
+            } else if (std::strcmp(dtype, "int32") == 0) {
+                int *data = new int[_linear_size];
+                std::fill(data, data + _linear_size, 1);
+                return new Tensor<int>(data, shape, ndim, device, DType::INT32);
+            } else {
+                throw std::runtime_error("Unsupported dtype!");
+            }
+        } catch(const std::exception& e) {
+            last_error = e.what();
+            return nullptr;
+        }
+    }
+
+    BaseTensor *zeros(int *shape, int ndim, const char *device, const char *dtype) {
+        try {
+            int _linear_size = 1;
+            for (int i = 0; i < ndim; i++) {
+                _linear_size *= shape[i];
+            }
+            if (std::strcmp(dtype, "float32") == 0) {
+                float *data = new float[_linear_size];
+                std::fill(data, data + _linear_size, 0.0f);
+                return new Tensor<float>(data, shape, ndim, device, DType::FLOAT32);
+            } else if (std::strcmp(dtype, "int32") == 0) {
+                int *data = new int[_linear_size];
+                std::fill(data, data + _linear_size, 0);
+                return new Tensor<int>(data, shape, ndim, device, DType::INT32);
+            } else {
+                throw std::runtime_error("Unsupported dtype!");
+            }
+        } catch(const std::exception& e) {
+            last_error = e.what();
+            return nullptr;
+        }
+    }
 }

--- a/lumine/csrc/tensor.h
+++ b/lumine/csrc/tensor.h
@@ -69,6 +69,8 @@ extern "C" {
     BaseTensor *tensor_sub(const BaseTensor* tensor1, const BaseTensor* tensor2);
     BaseTensor *tensor_mul(const BaseTensor* tensor1, const BaseTensor* tensor2);
     BaseTensor *reshape(BaseTensor* tensor, int* shape, int ndim);
+    BaseTensor *ones(int* shape, int ndim, const char* device, const char* dtype);
+    BaseTensor *zeros(int* shape, int ndim, const char* device, const char* dtype);
 }
 
 #endif // TENSOR_H

--- a/lumine/tensor.py
+++ b/lumine/tensor.py
@@ -96,7 +96,7 @@ class tensor:
         if not tensor:
             error_msg = cls._lib.get_last_error()
             if error_msg:
-                raise RuntimeError(error_msg.decode("utf-8"))
+                raise ValueError(error_msg.decode("utf-8"))
             else:
                 raise RuntimeError("Unknown error! Please report this issue.")
 
@@ -274,4 +274,15 @@ class tensor:
 
         return tensor(
             _tensor=tensor_ptr, dtype=self.dtype, device=self.device, ndim=len(shape)
+        )
+    
+    def __matmul__(self, other):
+        _tensor = self._lib.tensor_matmul(self._tensor, other._tensor)
+        self.check_error(_tensor)
+
+        return tensor(
+            _tensor=_tensor,
+            dtype=self.dtype,
+            device=self.device,
+            ndim=max(self.ndim, other.ndim),
         )

--- a/lumine/tensor.py
+++ b/lumine/tensor.py
@@ -82,14 +82,14 @@ class tensor:
         """
         arr = ctypes.cast(
             self._lib.print_tensor(self._tensor), ctypes.c_char_p
-        ).value.decode("utf-8")
+        ).value.decode("utf-8")+'\n'
         return arr
 
     def __repr__(self):
         arr = ctypes.cast(
             self._lib.print_tensor(self._tensor), ctypes.c_char_p
         ).value.decode("utf-8")
-        return f"array({arr}, dtype: {self.dtype.decode()}, device: {self.device.decode()})"
+        return f"array({arr}, dtype: {self.dtype.decode()}, device: {self.device.decode()})\n"
 
     @classmethod
     def check_error(cls, tensor):

--- a/tests/tensor_test.py
+++ b/tests/tensor_test.py
@@ -1,13 +1,13 @@
 import pytest
 import numpy as np
-from lumine import tensor
+import lumine as lm
 
 @pytest.fixture
 def generate_tensor():
     """Fixture to generate tensors for given shapes and dtype."""
     def _generate(shape, dtype="int32", min_val=0, max_val=100):
         array = np.random.randint(min_val, max_val + 1, size=shape, dtype=dtype)
-        return tensor(array.tolist()), array
+        return lm.tensor(array.tolist()), array
     return _generate
 
 @pytest.mark.parametrize("shape", [(3, 4), (2, 3, 4), (5, 5, 5)])
@@ -70,7 +70,6 @@ def test_broadcast_sum(generate_tensor, shapes):
 def test_broadcast_sub(generate_tensor, shapes):
     _tensor1, np_array1 = generate_tensor(shapes[0])
     _tensor2, np_array2 = generate_tensor(shapes[1])
-    #assert (_tensor1 - _tensor2).tolist() == (_tensor2 - _tensor1).tolist()
     assert (_tensor1 - _tensor2).tolist() == (np_array1 - np_array2).tolist()
     assert (_tensor2 - _tensor1).tolist() == (np_array2 - np_array1).tolist()
 
@@ -92,3 +91,10 @@ def test_broadcast_mul(generate_tensor, shapes):
     assert (_tensor1 * _tensor2).tolist() == (_tensor2 * _tensor1).tolist()
     assert (_tensor1 * _tensor2).tolist() == (np_array1 * np_array2).tolist()
 
+@pytest.mark.parametrize("shape", [(3, 4), (2, 3, 4), (5, 5, 5)])
+def test_ones_zeros_ones_like_zeros_like(generate_tensor, shape):
+    _tensor, np_array = generate_tensor(shape)
+    assert lm.ones(shape).tolist() == np.ones(shape).tolist()
+    assert lm.zeros(shape).tolist() == np.zeros(shape).tolist()
+    assert lm.ones_like(_tensor).tolist() == np.ones(shape).tolist()
+    assert lm.zeros_like(_tensor).tolist() == np.zeros(shape).tolist()

--- a/tests/tensor_test.py
+++ b/tests/tensor_test.py
@@ -2,28 +2,35 @@ import pytest
 import numpy as np
 import lumine as lm
 
+
 @pytest.fixture
 def generate_tensor():
     """Fixture to generate tensors for given shapes and dtype."""
+
     def _generate(shape, dtype="int32", min_val=0, max_val=100):
         array = np.random.randint(min_val, max_val + 1, size=shape, dtype=dtype)
         return lm.tensor(array.tolist()), array
+
     return _generate
+
 
 @pytest.mark.parametrize("shape", [(3, 4), (2, 3, 4), (5, 5, 5)])
 def test_shape(generate_tensor, shape):
     _tensor, np_array = generate_tensor(shape)
     assert _tensor.shape == np_array.shape
 
+
 @pytest.mark.parametrize("shape", [(3, 4), (2, 3, 4), (5, 5, 5)])
 def test_subtensor(generate_tensor, shape):
     _tensor, np_array = generate_tensor(shape)
     assert _tensor[0].shape == np_array[0].shape
 
+
 @pytest.mark.parametrize("shape", [(3, 4), (2, 3, 4), (5, 5, 5)])
 def test_tolist(generate_tensor, shape):
     _tensor, np_array = generate_tensor(shape)
     assert _tensor.tolist() == np_array.tolist()
+
 
 @pytest.mark.parametrize("shape", [(5, 5, 5)])
 def test_add(generate_tensor, shape):
@@ -31,11 +38,13 @@ def test_add(generate_tensor, shape):
     _tensor2, np_array2 = generate_tensor(shape)
     assert (_tensor1 + _tensor2).tolist() == (np_array1 + np_array2).tolist()
 
+
 @pytest.mark.parametrize("shape", [(5, 5, 5), (100, 99, 1, 30), (200, 1, 99)])
 def test_sub(generate_tensor, shape):
     _tensor1, np_array1 = generate_tensor(shape)
     _tensor2, np_array2 = generate_tensor(shape)
     assert (_tensor1 - _tensor2).tolist() == (np_array1 - np_array2).tolist()
+
 
 @pytest.mark.parametrize(
     "shapes",
@@ -53,7 +62,6 @@ def test_broadcast_sum(generate_tensor, shapes):
     _tensor2, np_array2 = generate_tensor(shapes[1])
     assert (_tensor1 + _tensor2).tolist() == (_tensor2 + _tensor1).tolist()
     assert (_tensor1 + _tensor2).tolist() == (np_array1 + np_array2).tolist()
-
 
 
 @pytest.mark.parametrize(
@@ -91,6 +99,7 @@ def test_broadcast_mul(generate_tensor, shapes):
     assert (_tensor1 * _tensor2).tolist() == (_tensor2 * _tensor1).tolist()
     assert (_tensor1 * _tensor2).tolist() == (np_array1 * np_array2).tolist()
 
+
 @pytest.mark.parametrize("shape", [(3, 4), (2, 3, 4), (5, 5, 5)])
 def test_ones_zeros_ones_like_zeros_like(generate_tensor, shape):
     _tensor, np_array = generate_tensor(shape)
@@ -98,3 +107,46 @@ def test_ones_zeros_ones_like_zeros_like(generate_tensor, shape):
     assert lm.zeros(shape).tolist() == np.zeros(shape).tolist()
     assert lm.ones_like(_tensor).tolist() == np.ones(shape).tolist()
     assert lm.zeros_like(_tensor).tolist() == np.zeros(shape).tolist()
+
+
+@pytest.mark.parametrize(
+    "a_shape, b_shape, error",
+    [
+        ((2, 3), (3, 4), True),  # Unbatched valid case
+        ((3, 2), (2, 3), True),  # Another unbatched valid case
+        (
+            (4, 3),
+            (2, 3),
+            False,
+        ),  # Unbatched incompatible shapes (should raise an error)
+        ((2, 3, 4), (2, 4, 5), True),  # Batched valid case
+        ((3, 2, 3), (3, 3, 2), True),  # Another batched valid case
+        (
+            (2, 3, 4),
+            (3, 4, 5),
+            False,
+        ),  # Incompatible batch sizes (should raise an error)
+        ((1, 2, 3, 4), (1, 2, 4, 5), True),  # Higher-dimensional batch, valid
+        ((2, 1, 3, 4), (1, 2, 4, 5), True),  # Broadcasting batch, valid
+        ((2, 3, 4), (4, 5), True),  # Implicit broadcasting, valid
+        ((2, 3, 4), (3, 4, 5), False),  # Incompatible batch size, should raise an error
+        (
+            (1, 2, 3, 4),
+            (2, 3, 4, 5),
+            False,
+        ),  # Incompatible batch size, should raise an error
+    ],
+)
+def test_matmul(generate_tensor, a_shape, b_shape, error):
+    a_tensor, a_np = generate_tensor(a_shape)
+    b_tensor, b_np = generate_tensor(b_shape)
+
+    try:
+        result = lm.matmul(a_tensor, b_tensor)
+        expected = np.matmul(a_np, b_np)
+        assert result.tolist() == expected.tolist()
+    except ValueError:
+        if not error:
+            pass
+        else:
+            raise


### PR DESCRIPTION
This adds codes for ones, zeros, and also matmul
matmul is ~ to naive but this one takes advantage of cache so expect it to be a little bit more faster.

we need to have benchmark of some sort to test these. ofc we will improve matmul in future but lets make it less priority for now since we are will implement this in cuda as well (which is what we will be using)

but please check if everything is working or not.
thanks

updates:
after benchmarking with numpy 
a = lm.ones((1000, 1000))
b = lm.ones((1000, 1000))
a@b

took 8sec while numpy took just 0.05 seconds 
now i have done some optimizations and made it 4seconds and now 0.1 seconds. I will look into somemore optimizations but ig for now its fine. You can go ahead and merge if you think everything is alright. 
